### PR TITLE
- Perlin generators now support alpha images

### DIFF
--- a/src/com/corax/graphics/generators/gradientperlin/GradientPerlinGenerator.java
+++ b/src/com/corax/graphics/generators/gradientperlin/GradientPerlinGenerator.java
@@ -18,7 +18,7 @@ public class GradientPerlinGenerator implements IGradientPerlinGenerator {
 		int width = (int)Math.pow(octaveSize, octaves);
 		int height = width;
 		
-		WritableRaster target = RasterUtils.createRaster(width, height);
+		WritableRaster target = RasterUtils.createRasterWithAlpha(width, height);
 		
 		float[][] tempMap = new float[width][height];
 		

--- a/src/com/corax/graphics/generators/perlinnoise/PerlinNoiseGenerator.java
+++ b/src/com/corax/graphics/generators/perlinnoise/PerlinNoiseGenerator.java
@@ -19,7 +19,7 @@ public class PerlinNoiseGenerator implements IPerlinNoiseGenerator {
 		int width = (int)Math.pow(octaveSize, octaves);
 		int height = width;
 
-		WritableRaster target = RasterUtils.createRaster(width, height);
+		WritableRaster target = RasterUtils.createRasterWithAlpha(width, height);
 
 		float[][] tempMap = new float[width][height];
 


### PR DESCRIPTION
Perlin generators now return 4 byte ARBG instead of 3 byte RGB.